### PR TITLE
Zip streams

### DIFF
--- a/src/MiniKanren.ml
+++ b/src/MiniKanren.ml
@@ -21,7 +21,7 @@ module Stream =
 
     type 'a t = Nil | Cons of 'a * 'a t | Lazy of 'a t Lazy.t
 
-    let from_fun (f: unit -> 'a t) : 'a t = Lazy (Lazy.lazy_from_fun f)
+    let from_fun (f: unit -> 'a t) : 'a t = Lazy (Lazy.from_fun f)
 
     let nil = Nil
 
@@ -64,12 +64,19 @@ module Stream =
     let rec map f = function
     | Nil -> Nil
     | Cons (x, xs) -> Cons (f x, map f xs)
-    | Lazy s -> Lazy (Lazy.lazy_from_fun (fun () -> map f @@ Lazy.force s))
+    | Lazy s -> Lazy (Lazy.from_fun (fun () -> map f @@ Lazy.force s))
 
     let rec iter f = function
     | Nil -> ()
     | Cons (x, xs) -> f x; iter f xs
     | Lazy s -> iter f @@ Lazy.force s
+
+    let rec zip fs gs = match (fs, gs) with
+    | Nil, _ -> Nil
+    | _, Nil -> Nil
+    | Cons (x, xs), Cons (y, ys) -> Cons ((x, y), zip xs ys)
+    | _, Lazy s -> Lazy (Lazy.from_fun (fun () -> zip fs (Lazy.force s)))
+    | Lazy s, _ -> Lazy (Lazy.from_fun (fun () -> zip (Lazy.force s) gs))
 
   end
 

--- a/src/MiniKanren.ml
+++ b/src/MiniKanren.ml
@@ -72,8 +72,9 @@ module Stream =
     | Lazy s -> iter f @@ Lazy.force s
 
     let rec zip fs gs = match (fs, gs) with
-    | Nil, _ -> Nil
-    | _, Nil -> Nil
+    | Nil, Nil -> Nil
+    | Nil, _ -> invalid_arg "streams have different lengths"
+    | _, Nil -> invalid_arg "streams have different lengths"
     | Cons (x, xs), Cons (y, ys) -> Cons ((x, y), zip xs ys)
     | _, Lazy s -> Lazy (Lazy.from_fun (fun () -> zip fs (Lazy.force s)))
     | Lazy s, _ -> Lazy (Lazy.from_fun (fun () -> zip (Lazy.force s) gs))

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -52,7 +52,8 @@ module Stream :
     (** [iter f s] iterates function [f] over the stream [s] *)
     val iter : ('a -> unit) -> 'a t -> unit
 
-    (** [zip s s'] returns the stream of pairs where first element is taken from [s] and second from [s'] *)
+    (** [zip s s'] returns the stream of pairs where first element is taken from [s] and second from [s'];
+        raises Invalid_argument if the two streams have different lengths *)
     val zip : 'a t -> 'b t -> ('a * 'b) t 
   end
 

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -52,6 +52,8 @@ module Stream :
     (** [iter f s] iterates function [f] over the stream [s] *)
     val iter : ('a -> unit) -> 'a t -> unit
 
+    (** [zip s s'] returns the stream of pairs where first element is taken from [s] and second from [s'] *)
+    val zip : 'a t -> 'b t -> ('a * 'b) t 
   end
 
 (** {3 States and goals} *)


### PR DESCRIPTION
Example use case:

```ocaml
let parts c = run qr (fun q  r  -> Nat.addo q r (inj_nat c))
                     (fun qs rs -> Stream.zip (Stream.map prj_nat qs) (Stream.map prj_nat rs))
```