### PR TITLE
Added conde in the opposite direction.

### DIFF
--- a/Makefile.ob
+++ b/Makefile.ob
@@ -37,7 +37,8 @@ clean: clean_tests
 	#$(MAKE) -C regression clean
 
 ######################## Tests related stuff  ##########################
-REGRES_CASES := 000 001 004 005 006 007 009 010 011 013 014 015runaway 016sorto
+REGRES_CASES := 000 001 004 005 006 007 009 010 011 013 014 015runaway 016sorto \
+	017condeorder
 
 define TESTRULES
 BYTE_TEST_EXECUTABLES += regression/test$(1).byte
@@ -92,10 +93,10 @@ test: tests
 
 ######################## Installation related stuff ##########################
 INSTALL_TARGETS=META \
-	$(wildcard _build/regression/tester.cmi) \
-	$(wildcard _build/regression/tester.cmo) \
-	$(wildcard _build/regression/tester.cmx) \
-	$(wildcard _build/regression/tester.o) \
+	_build/regression/tester.cmi \
+	_build/regression/tester.cmo \
+	_build/regression/tester.cmx \
+	_build/regression/tester.o \
 	$(wildcard _build/src/*.cmi) \
 	_build/src/MiniKanren.cmx \
 	_build/src/MiniKanren.cma \
@@ -136,6 +137,7 @@ bundle: rmbundledir $(BUNDLEDIR)
 	$(MAKE) -f Makefile.ob really_make_bundle
 
 really_make_bundle: $(MAKE_BUNDLE_TARGETS)
+	$(MAKE) $(MAKE_BUNDLE_TARGETS)
 
 install: bundle
 	ocamlfind install ocanren $(BUNDLEDIR)/*

--- a/_tags
+++ b/_tags
@@ -15,7 +15,7 @@ true: short_paths
 <regression/test0*.*>: package(GT,GT.syntax.all), syntax(camlp5o)
 #<regression/test004.ml> or <regression/test009.ml> or <regression/test005.ml> or <regression/test000.ml> : use_pa_minkanren
 #<regression/test004.*>:
-<regression/test016*.*> or <regression/test015*.*> or <regression/test014.*> or <regression/test013.*> or <regression/test012.*> or <regression/test010.*> or <regression/test009.*> or <regression/test011.*> or <regression/test007.*> or <regression/test006.*> or <regression/test005.*> or <regression/test004.*> or <regression/test001.*> or <regression/test000.*>: syntax(camlp5o), package(logger.syntax)
+<regression/test017*> or <regression/test016*.*> or <regression/test015*.*> or <regression/test014.*> or <regression/test013.*> or <regression/test012.*> or <regression/test010.*> or <regression/test009.*> or <regression/test011.*> or <regression/test007.*> or <regression/test006.*> or <regression/test005.*> or <regression/test004.*> or <regression/test001.*> or <regression/test000.*>: syntax(camlp5o), package(logger.syntax)
 <regression/test015*.*> or <regression/test014.*> or <regression/test013.*> or <regression/test012.*> or <regression/test011.*> or <regression/test010.*> or <regression/test009.*> or <regression/test007.*> or <regression/test006.*> or <regression/test005.*> or <regression/test004.*> or <regression/test003.*>: use_pa_minikanren, package(GT.syntax.all)
 
 ####################################################################

--- a/regression/orig/test017condeorder.log
+++ b/regression/orig/test017condeorder.log
@@ -1,0 +1,16 @@
+fun q -> (&&&) ((===) q (inj_int 1)) (conde [f1f; f2f; f3f]), all answers {
+f3
+f2
+f1
+}
+fun q -> (&&&) ((===) q (inj_int 1)) (condel [f1f; f2f; f3f]), all answers {
+f1
+f2
+f3
+}
+fun q -> (&&&) ((===) q (inj_int 1)) ((?&) [f1s; f2s; f3s]), all answers {
+f1
+f2
+f3
+q=1;
+}

--- a/regression/test017condeorder.ml
+++ b/regression/test017condeorder.ml
@@ -1,0 +1,16 @@
+open MiniKanren
+open Tester
+
+let f1f state = print_endline "f1"; failure state
+let f2f state = print_endline "f2"; failure state
+let f3f state = print_endline "f3"; failure state
+
+let f1s state = print_endline "f1"; success state
+let f2s state = print_endline "f2"; success state
+let f3s state = print_endline "f3"; success state
+
+let () =
+  run_exn string_of_int (-1) q qh (REPR(fun q -> (q=== inj_int 1) &&& conde  [ f1f; f2f; f3f ]));
+  run_exn string_of_int (-1) q qh (REPR(fun q -> (q=== inj_int 1) &&& condel [ f1f; f2f; f3f ]));
+  run_exn string_of_int (-1) q qh (REPR(fun q -> (q=== inj_int 1) &&& ?&     [ f1s; f2s; f3s ]));
+  ()

--- a/src/MiniKanren.ml
+++ b/src/MiniKanren.ml
@@ -511,6 +511,12 @@ let rec (?&) = function
 | h::t -> h &&& ?& t
 
 let conde = (?|)
+let conder = conde
+
+let rec condel = function
+| [h]  -> h
+| h::t -> (condel t) ||| h
+
 
 module Fresh =
   struct

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -121,13 +121,21 @@ val disj : goal -> goal -> goal
 (** [|||] is left-associative infix synonym for [disj] *)
 val (|||) : goal -> goal -> goal
 
-(** [?| [s1; s2; ...; sk]] calculates [s1 ||| s2 ||| ... ||| sk] for a non-empty list of goals *)
+(** [?| [s1; s2; ...; sk]] calculates [s1 ||| s2 ||| ... ||| sk] for a
+    non-empty list of goals. Calculations are performed from right to left. *)
 val (?|) : goal list -> goal
 
 (** [conde] is a synonym for [?|] *)
 val conde : goal list -> goal
 
-(** [?& [s1; s2; ...; sk]] calculates [s1 &&& s2 && ... &&& sk] for a non-empty list of goals *)
+(** [conder] is a synonym for [?|] and [conde] *)
+val conder : goal list -> goal
+
+(** [condel] is the same as (?|) but calculation from left to right *)
+val condel : goal list -> goal
+
+(** [?& [s1; s2; ...; sk]] calculates [s1 &&& s2 && ... &&& sk] for a
+    non-empty list of goals; evaluation from left to right *)
 val (?&) : goal list -> goal
 
 (** {2 Some predefined goals} *)


### PR DESCRIPTION
Conde by default worked from right to left. (?&) worked from left
to right as expected.

Now we have separate conde primitives for both directions.
Also a test to check actual direction.