### PR TITLE
Minor fixes

### DIFF
--- a/regression/orig/test005.log
+++ b/regression/orig/test005.log
@@ -1,4 +1,4 @@
-fun q -> lookupo varX (inj_list []) q, 1 answer {
+fun q -> lookupo varX (inj_list_p []) q, 1 answer {
 }
 fun q -> lookupo varX (inj_list_p [varX, v varX]) q, 1 answer {
 q=V ("x");

--- a/regression/orig/test009.log
+++ b/regression/orig/test009.log
@@ -1,19 +1,19 @@
-fun q -> pExpr (inj_list [(!!) Id]) q, 1 answer {
+fun q -> pExpr (inj_listi [(!!) Id]) q, 1 answer {
 q=I ();
 }
-fun q -> pExpr (inj_list [(!!) Id; (!!) Mul; (!!) Id]) q, 1 answer {
+fun q -> pExpr (inj_listi [(!!) Id; (!!) Mul; (!!) Id]) q, 1 answer {
 q=M (I (), I ());
 }
-fun q -> pExpr (inj_list [(!!) Id; (!!) Mul; (!!) Id; (!!) Mul; (!!) Id]) q, 1 answer {
+fun q -> pExpr (inj_listi [(!!) Id; (!!) Mul; (!!) Id; (!!) Mul; (!!) Id]) q, 1 answer {
 q=M (I (), M (I (), I ()));
 }
-fun q -> pExpr (inj_list [(!!) Id; (!!) Mul; (!!) Id; (!!) Add; (!!) Id]) q, 1 answer {
+fun q -> pExpr (inj_listi [(!!) Id; (!!) Mul; (!!) Id; (!!) Add; (!!) Id]) q, 1 answer {
 q=A (M (I (), I ()), I ());
 }
-fun q -> pExpr (inj_list [(!!) Id; (!!) Add; (!!) Id; (!!) Mul; (!!) Id]) q, 1 answer {
+fun q -> pExpr (inj_listi [(!!) Id; (!!) Add; (!!) Id; (!!) Mul; (!!) Id]) q, 1 answer {
 q=A (I (), M (I (), I ()));
 }
-fun q -> pExpr (inj_list [(!!) Id; (!!) Add; (!!) Id; (!!) Add; (!!) Id]) q, 1 answer {
+fun q -> pExpr (inj_listi [(!!) Id; (!!) Add; (!!) Id; (!!) Add; (!!) Id]) q, 1 answer {
 q=A (I (), A (I (), I ()));
 }
 fun q -> pExpr q (m (i ()) (i ())), 1 answer {

--- a/regression/orig/test013.log
+++ b/regression/orig/test013.log
@@ -74,7 +74,7 @@ q=S (S (O ()));
 fun q -> List.lengtho (nats [1; 2; 3; 4]) q, 1 answer {
 q=S (S (S (S (O ()))));
 }
-fun q -> List.lengtho (inj_list [(!!) (); (!!) (); (!!) ()]) q, 1 answer {
+fun q -> List.lengtho (inj_list (!!) [(); (); ()]) q, 1 answer {
 q=S (S (S (O ())));
 }
 fun q -> List.lengtho (bools [false; true]) q, 1 answer {

--- a/regression/test001.ml
+++ b/regression/test001.ml
@@ -3,7 +3,7 @@ open Tester
 open Printf
 open GT
 
-let ilist xs = inj_list @@ List.map (!!) xs
+let ilist xs = inj_list (!!) xs
 let just_a a = a === !!5
 
 let a_and_b a =

--- a/regression/test002sort.ml
+++ b/regression/test002sort.ml
@@ -65,7 +65,7 @@ let _ =
                 printf "%s\n%!"  @@ (if rr#is_open
                 then
                   GT.(show List.logic (show Nat.logic)) @@
-                    rr#refine (List.reify Nat.reify) ~inj:(List.inj_ground Nat.inj_ground)
+                    rr#refine (List.reify Nat.reify) ~inj:(List.to_logic Nat.to_logic)
                 else
                   GT.(show List.ground (show Nat.ground) rr#prj)
                 )
@@ -74,7 +74,7 @@ let _ =
 
 (* Making regular sorting from relational one *)
 let sort l =
-  List.prj_ground Nat.prj_ground @@
+  List.to_list Nat.to_int @@
   run q (sorto @@ inj_nat_list l)
         (fun qs -> Stream.hd qs |> (fun rr -> rr#prj))
 
@@ -84,7 +84,7 @@ let rec fact = function 0 -> 1 | n -> n * fact (n-1)
 
 (* Making permutations from relational sorting *)
 let perm l =
-  List.map (List.prj_ground Nat.prj_ground) @@
+  List.map (List.to_list Nat.to_int) @@
   run q (fun q -> sorto q @@ inj_nat_list (List.sort Pervasives.compare l))
         (fun qs ->
           qs |> Stream.take ~n:(fact @@ List.length l) |>
@@ -92,7 +92,7 @@ let perm l =
 
 (* More hardcore version: no standard sorting required *)
 let perm' l =
-  List.map (List.prj_ground Nat.prj_ground) @@
+  List.map (List.to_list Nat.to_int) @@
   run q (fun q -> fresh (r) (sorto (inj_nat_list l) r) (sorto q r))
         (fun qs ->
           qs |> Stream.take ~n:(fact @@ List.length l)

--- a/regression/test005.ml
+++ b/regression/test005.ml
@@ -4,12 +4,12 @@ open MiniKanren
 open Tester
 open Stlc
 
-module GTyp = 
+module GTyp =
   struct
 
-    module T = 
-      struct    
-        @type ('a, 'b) t = 
+    module T =
+      struct
+        @type ('a, 'b) t =
 	| P   of 'a      (* primitive *)
         | Arr of 'b * 'b (* arrow *)
         with gmap, show
@@ -67,11 +67,11 @@ let infero expr typ =
 let show_string  = show(string)
 let show_stringl = show(logic) (show(string))
 
-let inj_list_p xs = inj_list @@ List.map (fun (x,y) -> inj_pair x y) xs
+let inj_list_p xs = inj_listi @@ List.map (fun (x,y) -> inj_pair x y) xs
 
 (* Without free variables *)
 let () =
-  run_exn GLam.show_rlam    1 q qh (REPR (fun q -> lookupo varX (inj_list [])  q                                   ));
+  run_exn GLam.show_rlam    1 q qh (REPR (fun q -> lookupo varX (inj_list_p [])  q                                   ));
   run_exn GLam.show_rlam    1 q qh (REPR (fun q -> lookupo varX (inj_list_p [(varX, v varX)]) q                    ));
   run_exn GLam.show_rlam    1 q qh (REPR (fun q -> lookupo varX (inj_list_p [(varY, v varY); (varX, v varX)]) q    ));
 

--- a/regression/test009.ml
+++ b/regression/test009.ml
@@ -7,10 +7,10 @@ open Tester
 
 let show_token = show(token)
 
-module GExpr = 
+module GExpr =
   struct
 
-    module T = 
+    module T =
       struct
         @type 'self t  = I | A of 'self * 'self | M of 'self * 'self with show, gmap
 
@@ -76,11 +76,11 @@ let runE_exn n = run_exn show_expr n
 let show_stream xs = show(List.ground) show_token xs
 
 let _ =
-  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_list [!!Id]) q                              ));
-  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_list [!!Id; !!Mul; !!Id]) q               ));
-  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_list [!!Id; !!Mul; !!Id; !!Mul; !!Id]) q));
-  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_list [!!Id; !!Mul; !!Id; !!Add; !!Id]) q));
-  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_list [!!Id; !!Add; !!Id; !!Mul; !!Id]) q));
-  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_list [!!Id; !!Add; !!Id; !!Add; !!Id]) q));
+  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_listi [!!Id]) q                              ));
+  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_listi [!!Id; !!Mul; !!Id]) q               ));
+  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_listi [!!Id; !!Mul; !!Id; !!Mul; !!Id]) q));
+  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_listi [!!Id; !!Mul; !!Id; !!Add; !!Id]) q));
+  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_listi [!!Id; !!Add; !!Id; !!Mul; !!Id]) q));
+  runE_exn   1   q   qh (REPR (fun q -> pExpr (inj_listi [!!Id; !!Add; !!Id; !!Add; !!Id]) q));
   run_exn show_stream 1   q   qh (REPR (fun q -> pExpr q (m (i ()) (i ()))                   ));
   ()

--- a/regression/test011.ml
+++ b/regression/test011.ml
@@ -2,8 +2,8 @@ open Printf
 open MiniKanren
 open Tester
 
-let (!) = inj_int
-let (!!) = inj_list
+let (!) = (!!)
+let (!!) = inj_listi
 
 let show_int_list   = GT.(show List.ground @@ show int)
 let show_intl_llist = GT.(show List.logic @@ show logic @@ show int)

--- a/regression/test011.ml
+++ b/regression/test011.ml
@@ -3,7 +3,7 @@ open MiniKanren
 open Tester
 
 let (!) = inj_int
-let (!!) = List.of_list
+let (!!) = inj_list
 
 let show_int_list   = GT.(show List.ground @@ show int)
 let show_intl_llist = GT.(show List.logic @@ show logic @@ show int)

--- a/regression/test013.ml
+++ b/regression/test013.ml
@@ -11,7 +11,7 @@ let show_option_nat = GT.(show option  (show Nat.ground))
 
 let (?$) = inj_nat
 let nats = inj_nat_list
-let bools bs = inj_list @@ List.map (!!) bs
+let bools = inj_list (!!)
 
 let sumo = List.foldro Nat.addo ?$0
 
@@ -35,7 +35,7 @@ let () =
   run_exn show_nat         1    q  qh (REPR (fun q     -> Nat.mulo ?$3 q   ?$6                           ));
   run_exn show_nat         1    q  qh (REPR (fun q     -> Nat.mulo ?$3 ?$0 q                             ));
   run_exn show_nat         1    q  qh (REPR (fun q     -> Nat.mulo q   ?$5 ?$0                           ));
-  run_exn show_nat         3    q  qh (REPR (fun q     -> Nat.mulo q   ?$0 ?$0                           )) 
+  run_exn show_nat         3    q  qh (REPR (fun q     -> Nat.mulo q   ?$0 ?$0                           ))
 
 let () =
   run_exn show_nat         1    q  qh (REPR (fun q     -> sumo (nats []) q                               ));
@@ -45,7 +45,7 @@ let () =
 
 let () =
   run_exn show_nat         1    q   qh (REPR (fun q     -> List.lengtho (nats [1;2;3;4]) q                    ));
-  run_exn show_nat         1    q   qh (REPR (fun q     -> List.lengtho (inj_list [!!(); !!(); !!()]) q    ));
+  run_exn show_nat         1    q   qh (REPR (fun q     -> List.lengtho (inj_list (!!) [(); (); ()]) q    ));
   run_exn show_nat         1    q   qh (REPR (fun q     -> List.lengtho (bools [false; true]) q               ));
   run_exn show_nat         1    q   qh (REPR (fun q     -> List.lengtho (nats [4;3;2;1;0]) q                  ));
   run_exn show_nat_llist   1    q   qh (REPR (fun q     -> List.lengtho q ?$0                                 ));

--- a/regression/test015runaway.ml
+++ b/regression/test015runaway.ml
@@ -3,7 +3,7 @@ open MiniKanren
 open Tester
 open Printf
 
-let ilist xs = inj_list @@ List.map inj_int xs
+let ilist xs = inj_list (!!) xs
 
 let runaway_cell: (int List.ground, int logic List.logic) injected ref = ref (Obj.magic ())
 
@@ -15,7 +15,7 @@ let demo1 q =
 
 let demo2 q =
   call_fresh (fun r ->
-    (r === inj_int 5) &&&
+    (r === !!5) &&&
     conde [ (*(q === nil())
           ; *)(q === !runaway_cell)
           ]

--- a/samples/sort.ml
+++ b/samples/sort.ml
@@ -65,7 +65,7 @@ let _ =
                 printf "%s\n%!"  @@ (if rr#is_open
                 then
                   GT.(show List.logic (show Nat.logic)) @@
-                    rr#refine (List.reify Nat.reify) ~inj:(List.inj_ground Nat.inj_ground)
+                    rr#refine (List.reify Nat.reify) ~inj:(List.to_logic Nat.to_logic)
                 else
                   GT.(show List.ground (show Nat.ground) rr#prj)
                 )
@@ -74,7 +74,7 @@ let _ =
 
 (* Making regular sorting from relational one *)
 let sort l =
-  List.prj_ground Nat.prj_ground @@
+  List.to_list Nat.to_int @@
   run q (sorto @@ inj_nat_list l)
         (fun qs -> Stream.hd qs |> (fun rr -> rr#prj))
 
@@ -84,7 +84,7 @@ let rec fact = function 0 -> 1 | n -> n * fact (n-1)
 
 (* Making permutations from relational sorting *)
 let perm l =
-  List.map (List.prj_ground Nat.prj_ground) @@
+  List.map (List.to_list Nat.to_int) @@
   run q (fun q -> sorto q @@ inj_nat_list (List.sort Pervasives.compare l))
         (fun qs ->
           qs |> Stream.take ~n:(fact @@ List.length l) |>
@@ -92,7 +92,7 @@ let perm l =
 
 (* More hardcore version: no standard sorting required *)
 let perm' l =
-  List.map (List.prj_ground Nat.prj_ground) @@
+  List.map (List.to_list Nat.to_int) @@
   run q (fun q -> fresh (r) (sorto (inj_nat_list l) r) (sorto q r))
         (fun qs ->
           qs |> Stream.take ~n:(fact @@ List.length l)

--- a/samples/tree.ml
+++ b/samples/tree.ml
@@ -84,7 +84,7 @@ let insert : int -> inttree -> inttree = fun a t ->
    has to be inserted to convert t into t' *)
 let insert' t t' =
   run q (fun q  -> inserto q (inj_tree t) (inj_tree t'))
-        (fun qs -> Nat.prj_ground (Stream.hd qs)#prj)
+        (fun qs -> Nat.to_int (Stream.hd qs)#prj)
 
 (* Entry point *)
 let _ =

--- a/src/MiniKanren.ml
+++ b/src/MiniKanren.ml
@@ -963,6 +963,10 @@ module Nat = struct
     let rec to_logic: ground -> logic = fun n ->
       Value (GT.(gmap lnat) to_logic n)
 
+    let inj' = inj
+
+    let rec inj n = inj' @@ F.distrib @@ X.fmap inj n
+
     let o = inj@@lift O
     let s x = inj@@lift (S x)
 
@@ -1126,6 +1130,10 @@ module List =
     let rec to_logic : ('a -> 'b) -> 'a ground -> 'b logic = fun f xs ->
       Value (GT.(gmap llist) f (to_logic f) xs)
 
+    let inj' = inj
+
+    let rec inj fa x = inj' @@ F.distrib @@ X.fmap (fa) (inj fa) x
+
     type ('a,'b) groundi = ('a ground, 'b logic) injected
 
     let groundi =
@@ -1136,10 +1144,6 @@ module List =
           GT.show(ground) fa (Obj.magic l : 'a ground)
         end
       }
-
-    let inj' = inj
-
-    let rec inj fa x = inj' @@ F.distrib @@ X.fmap (fa) (inj fa) x
 
     let (%): ('a,'b) injected -> ('a,'b) groundi -> ('a,'b) groundi = cons
     let (%<): ('a,'b) injected -> ('a,'b) injected -> ('a,'b) groundi = fun x y -> cons x @@ cons y @@ nil ()

--- a/src/MiniKanren.ml
+++ b/src/MiniKanren.ml
@@ -963,12 +963,12 @@ module Nat = struct
     let rec to_logic: ground -> logic = fun n ->
       Value (GT.(gmap lnat) to_logic n)
 
+    let o = inj@@lift O
+    let s x = inj@@lift (S x)
+
     let inj' = inj
 
     let rec inj n = inj' @@ F.distrib @@ X.fmap inj n
-
-    let o = inj@@lift O
-    let s x = inj@@lift (S x)
 
     let zero = o
     let succ = s

--- a/src/MiniKanren.ml
+++ b/src/MiniKanren.ml
@@ -192,6 +192,10 @@ let (!!) x = inj (lift x)
 let inj_pair : ('a, 'c) injected -> ('b,'d) injected -> ('a * 'b, ('c * 'd) logic) injected =
   fun x y -> (x, y)
 
+let inj_triple : ('a, 'd) injected -> ('b,'e) injected -> ('c,'f) injected
+                 -> ('a * 'b * 'c, ('d * 'e * 'f) logic) injected =
+  fun x y z -> (x, y, z)
+
 external inj_int : int -> (int, int logic) injected = "%identity"
 
 exception Not_a_value
@@ -1051,8 +1055,6 @@ module List =
       if c#isVar x then var_of_injected_exn c x (reify arg_r)
       else F.reify arg_r (reify arg_r) c x
 
-    let rec of_list = function [] -> nil () | x::xs -> cons x (of_list xs)
-
     let ground = {
       GT.gcata = ();
       GT.plugins =
@@ -1128,6 +1130,12 @@ module List =
           GT.show(ground) fa (Obj.magic l : 'a ground)
         end
       }
+
+    let rec of_list = function [] -> Nil | x::xs -> Cons (x, (of_list xs))
+
+    let inj' = inj
+
+    let rec inj fa x = inj' @@ F.distrib @@ X.fmap (fa) (inj fa) x
 
     let (%): ('a,'b) injected -> ('a,'b) groundi -> ('a,'b) groundi = cons
     let (%<): ('a,'b) injected -> ('a,'b) injected -> ('a,'b) groundi = fun x y -> cons x @@ cons y @@ nil ()

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -393,7 +393,7 @@ module Fmap3 (T : T3) :
                 helper -> (('a, 'c, 'e) T.t, ('b, 'd, 'f) T.t logic as 'r) injected -> 'r
   end
 
-  module Fmap4 (T : T4) :
+module Fmap4 (T : T4) :
   sig
     val distrib : (('a,'b) injected, ('c, 'd) injected, ('e, 'f) injected, ('g, 'h) injected) T.t ->
                        (('a, 'c, 'e, 'g) T.t, ('b, 'd, 'f, 'h) T.t) injected
@@ -403,7 +403,7 @@ module Fmap3 (T : T3) :
                 helper -> (('a, 'c, 'e, 'g) T.t, ('b, 'd, 'f, 'h) T.t logic as 'r) injected -> 'r
   end
 
-  module Fmap5 (T : T5) :
+module Fmap5 (T : T5) :
   sig
     val distrib : (('a,'b) injected, ('c, 'd) injected, ('e, 'f) injected, ('g, 'h) injected, ('i, 'j) injected) T.t ->
                        (('a, 'c, 'e, 'g, 'i) T.t, ('b, 'd, 'f, 'h, 'j) T.t) injected
@@ -413,7 +413,7 @@ module Fmap3 (T : T3) :
                 helper -> (('a, 'c, 'e, 'g, 'i) T.t, ('b, 'd, 'f, 'h, 'j) T.t logic as 'r) injected -> 'r
   end
 
-  module Fmap6 (T : T6) :
+module Fmap6 (T : T6) :
   sig
     val distrib : (('a,'b) injected, ('c, 'd) injected, ('e, 'f) injected, ('g, 'h) injected, ('i, 'j) injected, ('k, 'l) injected) T.t ->
                        (('a, 'c, 'e, 'g, 'i, 'k) T.t, ('b, 'd, 'f, 'h, 'j, 'l) T.t) injected
@@ -562,20 +562,17 @@ module Nat :
     (** [of_int n] converts integer [n] into [ground]; negative integers become [O] *)
     val of_int : int -> ground
 
-    (** [to_int g] converts ground [n] into integer *)
+    (** [to_int g] converts ground [g] into integer *)
     val to_int : ground -> int
 
     (** Inject flat ground nat to logic nat *)
-    val inj_ground: ground -> logic
-
-    (** Project ground Peano number to plain int *)
-    val prj_ground : ground -> int
+    val to_logic: ground -> logic
 
     (** A type synonym for injected nat *)
     type groundi = (ground, logic) injected
 
-    val o : groundi
-    val s : groundi -> groundi
+    val zero : groundi
+    val succ : groundi -> groundi
 
     (** Relational addition *)
     val addo  : groundi -> groundi -> groundi -> goal
@@ -650,18 +647,14 @@ module List :
     (** A synonym for injected list *)
     type ('a,'b) groundi = ('a ground, 'b logic) injected
 
-    (** Inject plain ground list to logic list *)
-    val inj_ground : ('a -> 'b) -> 'a ground -> 'b logic
-
-    (** Project ground lists to normal OCaml lists *)
-    val prj_ground : ('a -> 'b) -> 'a ground -> 'b list
-
+    (** [of_list l] converts regular OCaml list [l] into isomorphic OCanren [ground] list *)
     val of_list : 'a list -> 'a ground
 
-    val inj : ('a -> (('a, 'b) injected)) -> 'a ground -> ('a, 'b) groundi
+    (** [to_list g] converts OCanren list [g] into iregular OCaml list *)
+    val to_list : 'a ground -> 'a list
 
-    (** [of_list l] makes a ground list from a regular one *)
-    (* val of_list : ('a, 'b) injected list -> ('a ground, 'b logic) injected *)
+    (** Inject plain ground list to logic list *)
+    val to_logic : ('a -> 'b) -> 'a ground -> 'b logic
 
     (** Reifier *)
     val reify : (helper -> ('a, 'b) injected -> 'b) -> helper -> ('a ground, 'b logic) injected -> 'b logic
@@ -717,13 +710,11 @@ module List :
 
   end
 
-(** [inj_list l] is a deforested synonym for injection *)
-val inj_list : ('a, 'b) injected list -> ('a, 'b) List.groundi
+(** [inj_list inj_a l] is a deforested synonym for injection *)
+val inj_list : ('a -> (('a, 'b) injected)) -> 'a ground -> ('a, 'b) groundi
 
 val inj_pair   : ('a, 'b) injected -> ('c, 'd) injected -> ('a * 'c, ('b * 'd) logic) injected
-val inj_triple : ('a, 'd) injected -> ('b,'e) injected -> ('c,'f) injected -> ('a * 'b * 'c, ('d * 'e * 'f) logic) injected
-val inj_list_p : (('a, 'b) injected * ('c, 'd) injected) list -> ('a * 'c, ('b * 'd) logic) List.groundi
-val inj_int    : int -> (int, int logic) injected
+val inj_triple : ('a, 'd) injected -> ('b, 'e) injected -> ('c,'f) injected -> ('a * 'b * 'c, ('d * 'e * 'f) logic) injected
 
 (** [inj_nat_list l] is a deforsted synonym for injection *)
 val inj_nat_list : int list -> (Nat.ground, Nat.logic) List.groundi

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -559,17 +559,20 @@ module Nat :
          show    : logic -> string >)
       GT.t
 
+    (** A type synonym for injected nat *)
+    type groundi = (ground, logic) injected
+
     (** [of_int n] converts integer [n] into [ground]; negative integers become [O] *)
     val of_int : int -> ground
 
     (** [to_int g] converts ground [g] into integer *)
     val to_int : ground -> int
 
-    (** Inject flat ground nat to logic nat *)
-    val to_logic: ground -> logic
+    (** Make logic nat from ground one *)
+    val to_logic : ground -> logic
 
-    (** A type synonym for injected nat *)
-    type groundi = (ground, logic) injected
+    (** Make injected nat from ground one *)
+    val inj : ground -> groundi
 
     val zero : groundi
     val succ : groundi -> groundi
@@ -655,6 +658,9 @@ module List :
 
     (** Make logic list from ground one *)
     val to_logic : ('a -> 'b) -> 'a ground -> 'b logic
+
+    (** Make injected list from ground one *)
+    val inj : ('a -> (('a, 'b) injected)) -> 'a ground -> ('a, 'b) groundi
 
     (** Reifier *)
     val reify : (helper -> ('a, 'b) injected -> 'b) -> helper -> ('a ground, 'b logic) injected -> 'b logic

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -49,6 +49,8 @@ module Stream :
 
     (** [iter f s] iterates function [f] over the stream [s] *)
     val iter : ('a -> unit) -> 'a t -> unit
+
+    val zip : 'a t -> 'b t -> ('a * 'b) t
   end
 
 (** {3 States and goals} *)
@@ -572,6 +574,9 @@ module Nat :
     (** A type synonym for injected nat *)
     type groundi = (ground, logic) injected
 
+    val o : groundi
+    val s : groundi -> groundi
+
     (** Relational addition *)
     val addo  : groundi -> groundi -> groundi -> goal
 
@@ -630,9 +635,6 @@ module List :
          show    : ('a -> string) -> 'a ground -> string >)
       GT.t
 
-    (** [of_list l] makes a ground list from a regular one *)
-    val of_list : ('a, 'b) injected list -> ('a ground, 'b logic) injected
-
     (** GT-compatible typeinfo for ['a logic] *)
     val logic :
       (unit,
@@ -645,14 +647,21 @@ module List :
           show    : ('a -> string) -> 'a logic -> GT.string  >)
         GT.t
 
+    (** A synonym for injected list *)
+    type ('a,'b) groundi = ('a ground, 'b logic) injected
+
     (** Inject plain ground list to logic list *)
     val inj_ground : ('a -> 'b) -> 'a ground -> 'b logic
 
     (** Project ground lists to normal OCaml lists *)
     val prj_ground : ('a -> 'b) -> 'a ground -> 'b list
 
-    (** A synonym for injected list *)
-    type ('a,'b) groundi = ('a ground, 'b logic) injected
+    val of_list : 'a list -> 'a ground
+
+    val inj : ('a -> (('a, 'b) injected)) -> 'a ground -> ('a, 'b) groundi
+
+    (** [of_list l] makes a ground list from a regular one *)
+    (* val of_list : ('a, 'b) injected list -> ('a ground, 'b logic) injected *)
 
     (** Reifier *)
     val reify : (helper -> ('a, 'b) injected -> 'b) -> helper -> ('a ground, 'b logic) injected -> 'b logic
@@ -689,7 +698,7 @@ module List :
     val reverso : ('a, 'b) groundi -> ('a, 'b) groundi -> goal
 
     (** Relational occurrence check (a shortcut) *)
-    val membero : ('a, 'b) groundi  -> ('a, 'b logic) injected  -> goal
+    val membero : ('a, 'b) groundi  -> ('a, 'b) injected  -> goal
 
     (** Relational check for empty list *)
     val nullo : _ groundi -> goal
@@ -712,6 +721,7 @@ module List :
 val inj_list : ('a, 'b) injected list -> ('a, 'b) List.groundi
 
 val inj_pair   : ('a, 'b) injected -> ('c, 'd) injected -> ('a * 'c, ('b * 'd) logic) injected
+val inj_triple : ('a, 'd) injected -> ('b,'e) injected -> ('c,'f) injected -> ('a * 'b * 'c, ('d * 'e * 'f) logic) injected
 val inj_list_p : (('a, 'b) injected * ('c, 'd) injected) list -> ('a * 'c, ('b * 'd) logic) List.groundi
 val inj_int    : int -> (int, int logic) injected
 

--- a/src/MiniKanren.mli
+++ b/src/MiniKanren.mli
@@ -648,12 +648,12 @@ module List :
     type ('a,'b) groundi = ('a ground, 'b logic) injected
 
     (** [of_list l] converts regular OCaml list [l] into isomorphic OCanren [ground] list *)
-    val of_list : 'a list -> 'a ground
+    val of_list : ('a -> 'b) -> 'a list -> 'b ground
 
-    (** [to_list g] converts OCanren list [g] into iregular OCaml list *)
-    val to_list : 'a ground -> 'a list
+    (** [to_list g] converts OCanren list [g] into regular OCaml list *)
+    val to_list : ('a -> 'b) -> 'a ground -> 'b list
 
-    (** Inject plain ground list to logic list *)
+    (** Make logic list from ground one *)
     val to_logic : ('a -> 'b) -> 'a ground -> 'b logic
 
     (** Reifier *)
@@ -711,7 +711,9 @@ module List :
   end
 
 (** [inj_list inj_a l] is a deforested synonym for injection *)
-val inj_list : ('a -> (('a, 'b) injected)) -> 'a ground -> ('a, 'b) groundi
+val inj_list : ('a -> ('a, 'b) injected) -> 'a list -> ('a, 'b) List.groundi
+
+val inj_listi : ('a, 'b) injected list -> ('a, 'b) List.groundi
 
 val inj_pair   : ('a, 'b) injected -> ('c, 'd) injected -> ('a * 'c, ('b * 'd) logic) injected
 val inj_triple : ('a, 'd) injected -> ('b, 'e) injected -> ('c,'f) injected -> ('a * 'b * 'c, ('d * 'e * 'f) logic) injected


### PR DESCRIPTION
1. Restore `zip` declaration in MiniKanren.mli
2. Fix type error in the declaration of `List.membero`
3. More consistent naming of inj/prj stuff (see MiniKanren.mli diff)
4. `zero` and `succ` functions in Nat module 

\+ promotion of test output