### PR TITLE
Normalization of disequality constraints

### DIFF
--- a/regression/orig/test011.log
+++ b/regression/orig/test011.log
@@ -84,7 +84,8 @@ fun q ->
          (fun () ->
             conj ((=/=) ((!!) [x; !1]) ((!!) [!2; y]))
               ((===) ((!!) [x; y]) q))), all answers {
-q=[_.11 [=/= 2]; _.12 [=/= 1]];
+q=[_.11 [=/= 2]; _.12];
+q=[_.11; _.12 [=/= 1]];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -133,7 +134,6 @@ fun q ->
          (fun () ->
             conj (conj ((=/=) a ((!!) [x; !1])) ((===) a ((!!) [z; !1])))
               ((===) x z))), all answers {
-q=_.10;
 }
 fun q ->
   MiniKanren.Fresh.three
@@ -168,7 +168,7 @@ fun q ->
 q=_.10;
 }
 fun q -> (&&&) ((=/=) !4 q) ((=/=) !3 q), all answers {
-q=_.10 [=/= 3; =/= 4];
+q=_.10 [=/= 4; =/= 3];
 }
 fun q -> (&&&) ((=/=) q !5) ((=/=) q !5), all answers {
 q=_.10 [=/= 5];
@@ -181,11 +181,12 @@ q=_.10;
 fun q ->
   MiniKanren.Fresh.two
     (fun x y -> delay (fun () -> conj ((===) ((!!) [x; y]) q) ((=/=) x y))), all answers {
-q=[_.11 [=/= _.12]; _.12 [=/= _.11]];
+q=[_.11 [=/= _.12]; _.12];
 }
 fun q ->
   Fresh.two (fun a d -> (?&) [(===) ((!!) [a; d]) q; (=/=) q ((!!) [!5; !6])]), all answers {
-q=[_.11 [=/= 5]; _.12 [=/= 6]];
+q=[_.11 [=/= 5]; _.12];
+q=[_.11; _.12 [=/= 6]];
 }
 fun q ->
   Fresh.two
@@ -196,7 +197,7 @@ q=[3; _.12];
 fun q ->
   MiniKanren.Fresh.two
     (fun x y -> delay (fun () -> conj ((===) ((!!) [x; y]) q) ((=/=) y x))), all answers {
-q=[_.11 [=/= _.12]; _.12 [=/= _.11]];
+q=[_.11; _.12 [=/= _.11]];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -204,7 +205,7 @@ fun q ->
        delay
          (fun () ->
             conj (conj ((===) ((!!) [x; y]) q) ((=/=) x y)) ((=/=) y x))), all answers {
-q=[_.11 [=/= _.12]; _.12 [=/= _.11]];
+q=[_.11 [=/= _.12]; _.12];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -212,7 +213,7 @@ fun q ->
        delay
          (fun () ->
             conj (conj ((===) ((!!) [x; y]) q) ((=/=) x y)) ((=/=) x y))), all answers {
-q=[_.11 [=/= _.12]; _.12 [=/= _.11]];
+q=[_.11 [=/= _.12]; _.12];
 }
 fun q -> (&&&) ((=/=) q !5) ((=/=) !5 q), all answers {
 q=_.10 [=/= 5];
@@ -226,7 +227,7 @@ fun q ->
               (conj ((===) ((!!) [x; y]) q)
                  ((=/=) ((!!) [x; y]) ((!!) [!5; !6])))
               ((=/=) x !5))), all answers {
-q=[_.11 [=/= 5]; _.12 [=/= 6]];
+q=[_.11 [=/= 5]; _.12];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -235,7 +236,7 @@ fun q ->
          (fun () ->
             conj (conj ((===) ((!!) [x; y]) q) ((=/=) x !5))
               ((=/=) ((!!) [x; y]) ((!!) [!5; !6])))), all answers {
-q=[_.11 [=/= 5]; _.12 [=/= 6]];
+q=[_.11 [=/= 5]; _.12];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -244,7 +245,7 @@ fun q ->
          (fun () ->
             conj (conj ((=/=) x !5) ((=/=) ((!!) [x; y]) ((!!) [!5; !6])))
               ((===) ((!!) [x; y]) q))), all answers {
-q=[_.11 [=/= 5]; _.12 [=/= 6]];
+q=[_.11 [=/= 5]; _.12];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -253,7 +254,7 @@ fun q ->
          (fun () ->
             conj (conj ((=/=) !5 x) ((=/=) ((!!) [x; y]) ((!!) [!5; !6])))
               ((===) ((!!) [x; y]) q))), all answers {
-q=[_.11 [=/= 5]; _.12 [=/= 6]];
+q=[_.11 [=/= 5]; _.12];
 }
 fun q ->
   MiniKanren.Fresh.two
@@ -262,7 +263,16 @@ fun q ->
          (fun () ->
             conj (conj ((=/=) !5 x) ((=/=) ((!!) [y; x]) ((!!) [!6; !5])))
               ((===) ((!!) [x; y]) q))), all answers {
-q=[_.11 [=/= 5]; _.12 [=/= 6]];
+q=[_.11 [=/= 5]; _.12];
+}
+fun q ->
+  MiniKanren.Fresh.two
+    (fun x y ->
+       delay
+         (fun () ->
+            conj (conj ((===) ((%) x y) q) ((=/=) ((%) x y) ((!!) [!1; x])))
+              ((===) y ((!!) [!2])))), all answers {
+q=[_.11; 2];
 }
 fun x ->
   MiniKanren.Fresh.two
@@ -272,7 +282,7 @@ fun x ->
 xs=[_.12 [=/= _.11]; 2];
 }
 fun q -> distincto ((%) !2 ((%<) !3 q)), all answers {
-q=_.35 [=/= 3; =/= 2];
+q=_.35 [=/= 2; =/= 3];
 }
 fun q -> remembero !1 ((%) !1 ((%) !2 ((%<) !1 !3))) q, all answers {
 q=[2; 3];

--- a/regression/test011.ml
+++ b/regression/test011.ml
@@ -12,6 +12,8 @@ let show_intl_llist = GT.(show List.logic @@ show logic @@ show int)
 let runInt n = runR MiniKanren.reify GT.(show int) GT.(show logic @@ show int) n
 let runIList n = runR (List.reify MiniKanren.reify) show_int_list show_intl_llist n
 
+let pair = Std.Pair.pair
+
 let _ =
   runInt       (-1) q qh (REPR (fun q -> (q =/= !1)       ));
   runIList     (-1) q qh (REPR (fun q -> (fresh (x y z)(x =/= y)(x === !![!0; z; !1])(y === !![!0; !1; !1]))                   ));
@@ -62,11 +64,14 @@ let _ =
   runIList            (-1) q qh (REPR (fun q -> (fresh (x y)(!![x; y] === q)(x =/= y)(x =/= y))           ));
   runInt              (-1) q qh (REPR (fun q -> ((q =/= !5) &&& (!5 =/= q))                  ));
 
-  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!![x; y] === q)(!![x; y] =/= !![!5; !6])(x =/= !5))                 ));
-  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!![x; y] === q)(x =/= !5)(!![x; y] =/= !![!5; !6]))                 ));
-  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(x =/= !5)(!![x; y] =/= !![!5; !6])(!![x; y] === q))                 ));
-  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!5 =/= x)(!![x; y] =/= !![!5; !6])(!![x; y] === q))                 ));
-  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!5 =/= x)(!![y; x] =/= !![!6; !5])(!![x; y] === q))                 ));
+  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!![x; y] === q)(!![x; y] =/= !![!5; !6])(x =/= !5))));
+  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!![x; y] === q)(x =/= !5)(!![x; y] =/= !![!5; !6]))));
+  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(x =/= !5)(!![x; y] =/= !![!5; !6])(!![x; y] === q))));
+  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!5 =/= x)(!![x; y] =/= !![!5; !6])(!![x; y] === q))));
+  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(!5 =/= x)(!![y; x] =/= !![!6; !5])(!![x; y] === q))));
+
+  runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(x%y === q)(x%y =/= !![!1; x])(y === !![!2]))));
+
 
   let xsh xs = ["xs", xs] in
   runIList (-1) q xsh (REPR (fun x -> (fresh (y z)(x =/= !![y; !2])(x === !![z; !2]))))


### PR DESCRIPTION
Refactoring of Disequality Constraints and fix for its reification (in a collabaration with @Kakadu).

There was strange behaviour in constraint's reification. 
Consider the two following queries:

`run (q r) ([q; r] =/= [1; 2])`
`run (q r) (q =/= 1 &&& r =/= 2)`

Although these two quieries have different meaning, they both reified to following answer:

`(_.0 [=/= 1], _.1 [=/= 2])`

This behaviour was not observed in Scheme implementation, because Scheme MK doesn't  assign disequalities to individual variables, rather it returns the `whole` disequality.

The solution in this PR is to normalize disequalities before reification, 
i.e. to split single disequality to the list of conjuncts.

For example, the query 

`run (q r) ([q; r] =/= [1; 2])`

Now returns a stream of two answers:

```
(_.0 [=/= 1], _.1)
(_.0, _.1 [=/= 2])
```