### PR TITLE
Run and Streams refactoring

### DIFF
--- a/regression/orig/test011.log
+++ b/regression/orig/test011.log
@@ -284,7 +284,7 @@ fun x ->
     (fun y z ->
        delay
          (fun () -> conj ((=/=) x ((!!) [y; !2])) ((===) x ((!!) [z; !2])))), all answers {
-xs=[_.12 [=/= _.11]; 2];
+q=[_.12 [=/= _.11]; 2];
 }
 fun q -> distincto ((%) !2 ((%<) !3 q)), all answers {
 q=_.35 [=/= 2; =/= 3];

--- a/regression/test002sort.ml
+++ b/regression/test002sort.ml
@@ -59,25 +59,24 @@ let rec sorto x y =
         (smallesto x s xs)   (* 2 *)
     ]
 
-let _ =
+let _ = Stream.take ~n:10 @@
   run four  (fun q1 q2 q3 p -> sorto (q1 % (q2 % (q3 % nil ()))) p)
-            (fun _  _  _  p ->
-              Stream.take ~n:10 p |> List.iter (fun rr ->
-                printf "%s\n%!"  @@ (if rr#is_open
-                then
-                  GT.(show List.logic (show Nat.logic)) @@
-                    rr#reify (List.reify Nat.reify)
-                else
-                  GT.(show List.ground (show Nat.ground) rr#prj)
-                )
+            (fun _  _  _  rr ->
+              printf "%s\n%!"  @@ (if rr#is_open
+              then
+                GT.(show List.logic (show Nat.logic)) @@
+                  rr#reify (List.reify Nat.reify)
+              else
+                GT.(show List.ground (show Nat.ground) rr#prj)
               )
             )
 
 (* Making regular sorting from relational one *)
 let sort l =
   List.to_list Nat.to_int @@
+  Stream.hd @@
   run q (sorto @@ nat_list l)
-        (fun qs -> Stream.hd qs |> (fun rr -> rr#prj))
+        (fun rr -> rr#prj)
 
 (* Veeeeery straightforward implementation of factorial *)
 let rec fact = function 0 -> 1 | n -> n * fact (n-1)
@@ -86,18 +85,16 @@ let rec fact = function 0 -> 1 | n -> n * fact (n-1)
 (* Making permutations from relational sorting *)
 let perm l =
   List.map (List.to_list Nat.to_int) @@
+  Stream.take ~n:(fact @@ List.length l) @@
   run q (fun q -> sorto q @@ nat_list (List.sort Pervasives.compare l))
-        (fun qs ->
-          qs |> Stream.take ~n:(fact @@ List.length l) |>
-          List.map (fun rr -> rr#prj))
+        (fun rr -> rr#prj)
 
 (* More hardcore version: no standard sorting required *)
 let perm' l =
   List.map (List.to_list Nat.to_int) @@
+  Stream.take ~n:(fact @@ List.length l) @@
   run q (fun q -> fresh (r) (sorto (nat_list l) r) (sorto q r))
-        (fun qs ->
-          qs |> Stream.take ~n:(fact @@ List.length l)
-          |> List.map (fun rr -> rr#prj))
+        (fun rr -> rr#prj)
 
 (* Entry point *)
 let _ =

--- a/regression/test011.ml
+++ b/regression/test011.ml
@@ -74,8 +74,7 @@ let _ =
   runIList           (-1) q qh (REPR (fun q -> (fresh (x y)(x%y === q)(x%y =/= !![!1; x])(y === !![!2]))));
 
 
-  let xsh xs = ["xs", xs] in
-  runIList (-1) q xsh (REPR (fun x -> (fresh (y z)(x =/= !![y; !2])(x === !![z; !2]))))
+  runIList (-1) q qh (REPR (fun x -> (fresh (y z)(x =/= !![y; !2])(x === !![z; !2]))))
 
 
 let () =

--- a/src/MiniKanrenCore.mli
+++ b/src/MiniKanrenCore.mli
@@ -22,17 +22,37 @@
 
 module Stream :
   sig
-    (** Internal stream type *)
-    type 'a internal
-
     (** Stream type *)
     type 'a t
+
+    (** Constructors *)
+
+    val nil : 'a t
+
+    val single : 'a -> 'a t
+
+    val cons : 'a -> 'a t -> 'a t
+
+    val from_fun : (unit -> 'a t) -> 'a t
+
+    val of_list : 'a list -> 'a t
 
     (** Emptiness test *)
     val is_empty : 'a t -> bool
 
-    (** Constructor *)
-    val from_fun : (unit -> 'a t) -> 'a t
+    (** [map f s] maps function [f] over the stream [s] *)
+    val map : ('a -> 'b) -> 'a t -> 'b t
+
+    (** [iter f s] iterates function [f] over the stream [s] *)
+    val iter : ('a -> unit) -> 'a t -> unit
+
+    (** [filter p g] filters the stream [g] using the predicate [p] (leaves only those elements [x], for which [p x = true]) *)
+    val filter : ('a -> bool) -> 'a t -> 'a t
+
+    val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+
+    (** [zip f g] returns a strem of corresponding pairs of [f] and [g]; fails for the streams of different lengths *)
+    val zip : 'a t -> 'b t -> ('a * 'b) t
 
     (** [retrieve ~n:n s] returns the list of [n]-first elements of [s] and the rest of the stream *)
     val retrieve : ?n:int -> 'a t -> 'a list * 'a t
@@ -45,18 +65,6 @@ module Stream :
 
     (** [hd s] gets a tail of the stream *)
     val tl : 'a t -> 'a t
-
-    (** [map f s] maps function [f] over the stream [s] *)
-    val map : ('a -> 'b) -> 'a t -> 'b t
-
-    (** [iter f s] iterates function [f] over the stream [s] *)
-    val iter : ('a -> unit) -> 'a t -> unit
-
-    (** [zip f g] returns a strem of corresponding pairs of [f] and [g]; fails for the streams of different lengths *)
-    val zip : 'a t -> 'b t -> ('a * 'b) t
-
-    (** [filter p g] filters the stream [g] using the predicate [p] (leaves only those elements [x], for which [p x = true]) *)
-    val filter : ('a -> bool) -> 'a t -> 'a t                                    
   end
 
 (** {3 States and goals} *)
@@ -70,7 +78,7 @@ module State :
 
 (** Goal converts a state into a lazy stream of states *)
 type 'a goal' = State.t -> 'a
-type goal = State.t Stream.internal goal'
+type goal = State.t Stream.t goal'
 
 (** {3 Logic values} *)
 
@@ -202,8 +210,10 @@ module Fresh :
     - [run two        (fun q r -> q === !!5 ||| r === !!6) (fun qs rs -> ]{i here [qs], [rs] --- streams of all values, associated with the variable [q] and [r], respectively}[)]
     - [run (succ one) (fun q r -> q === !!5 ||| r === !!6) (fun qs rs -> ]{i the same as the above}[)]
 *)
-val run : (unit -> ('a -> 'c goal') * ('d -> 'e -> 'f) * (State.t Stream.t -> 'h -> 'e) * ('c -> 'h * State.t Stream.internal)) ->
-          'a -> 'd -> 'f
+val run : (unit ->
+            ('a -> State.t -> 'b) * ('c -> State.t -> 'd) *
+            ('b -> 'c * State.t Stream.t) * ('e -> 'd -> 'f)) ->
+           'a -> 'e -> 'f Stream.t
 
 (** The primitive [delay] helps to construct recursive goals, which depend on themselves. For example,
     we can't write [let rec fives q = (q === !!5) ||| (fives q)] because the generation of this goal leads to
@@ -232,116 +242,177 @@ object
   method reify: (helper -> ('a, 'b) injected -> 'b) -> 'b
 end
 
+(* module RunCurried : sig
+  (** {3 Predefined numerals (one to five)} *)
+  val one : unit ->
+           ((('a, 'b) injected -> goal) ->
+            State.t -> ('a, 'b) injected * State.t Stream.t) *
+           (('c, 'd) injected -> State.t -> ('c, 'd) reified) * ('e -> 'e)
+
+  (** Successor function *)
+  val succ : (unit ->
+            ('a -> State.t -> 'b) * ('c -> State.t -> 'd) * ('e -> 'f * 'g)) ->
+           unit ->
+           ((('h, 'i) injected -> 'a) -> State.t -> ('h, 'i) injected * 'b) *
+           (('j, 'k) injected * 'c -> State.t -> ('j, 'k) reified * 'd) *
+           ('l * 'e -> ('l * 'f) * 'g)
+
+
+  val run :
+           (unit ->
+            ('a -> State.t -> 'b) * ('c -> State.t -> 'd) *
+            ('b -> 'c * State.t Stream.t)) ->
+           'a -> ('d Stream.t -> 'e) -> 'e
+
+end *)
+
+
 (** Successor function *)
 val succ : (unit ->
-            ('a -> 'b goal') * ('c -> 'd -> 'e) * (State.t Stream.t -> 'f -> 'g) * ('h -> 'i * 'j)) ->
+            ('a -> State.t -> 'b) * ('c -> State.t -> 'd) * ('e -> 'f * 'g) *
+            ('h -> 'i -> 'j)) ->
            unit ->
-           ((('k, 'l) injected -> 'a) -> (('k, 'l) injected * 'b) goal') *
-           (('m -> 'c) -> 'm * 'd -> 'e) *
-           (State.t Stream.t -> ('n, 'o) injected * 'f -> ('n, 'o) reified Stream.t * 'g) *
-           ('p * 'h -> ('p * 'i) * 'j)
+           ((('k, 'l) injected -> 'a) -> State.t -> ('k, 'l) injected * 'b) *
+           (('m, 'n) injected * 'c -> State.t -> ('m, 'n) reified * 'd) *
+           ('o * 'e -> ('o * 'f) * 'g) * (('p -> 'h) -> 'p * 'i -> 'j)
 
 (** {3 Predefined numerals (one to five)} *)
 val one : unit ->
-  ((('a,'c) injected -> State.t Stream.internal goal') -> (('a, 'c) injected * State.t Stream.internal) goal') *
-  (('d -> 'e) -> 'd -> 'e) *
-  (State.t Stream.t ->
-    ('f, 'g) injected -> ('f, 'g) reified Stream.t) *
-  ('h -> 'h)
+           ((('a, 'b) injected -> goal) ->
+            State.t -> ('a, 'b) injected * State.t Stream.t) *
+           (('c, 'd) injected -> State.t -> ('c, 'd) reified) * ('e -> 'e) *
+           (('f -> 'g) -> 'f -> 'g)
 
 val two : unit ->
-  ((('a,'d) injected -> ('b,'e) injected -> State.t Stream.internal goal') ->
-    (('a, 'd) injected * (('b, 'e) injected * State.t Stream.internal)) goal') *
-  (('f -> 'g -> 'h) -> 'f * 'g -> 'h) *
-  (State.t Stream.t ->
-    ('i, 'j) injected * ('k, 'l) injected ->
-    ('i, 'j) reified Stream.t *
-    ('k, 'l) reified Stream.t) *
-  ('m * ('n * 'o) -> ('m * 'n) * 'o)
+           ((('a, 'b) injected -> ('c, 'd) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected * (('c, 'd) injected * State.t Stream.t)) *
+           (('e, 'f) injected * ('g, 'h) injected ->
+            State.t -> ('e, 'f) reified * ('g, 'h) reified) *
+           ('i * ('j * 'k) -> ('i * 'j) * 'k) *
+           (('l -> 'm -> 'n) -> 'l * 'm -> 'n)
 
 val three : unit ->
-  ((('a,'e) injected -> ('b, 'f) injected -> ('c, 'g) injected -> State.t Stream.internal goal') ->
-    (('a, 'e) injected * (('b, 'f) injected * (('c, 'g) injected * State.t Stream.internal))) goal') *
-  (('h -> 'i -> 'j -> 'k) -> 'h * ('i * 'j) -> 'k) *
-  (State.t Stream.t ->
-    ('l, 'm) injected * (('n, 'o) injected * ('p, 'q) injected) ->
-    ('l, 'm) reified Stream.t *
-    (('n, 'o) reified Stream.t *
-    ('p, 'q) reified Stream.t)) *
-  ('r * ('s * ('t * 'u)) -> ('r * ('s * 't)) * 'u)
+           ((('a, 'b) injected ->
+             ('c, 'd) injected -> ('e, 'f) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected *
+            (('c, 'd) injected *
+             (('e, 'f) injected * State.t Stream.t))) *
+           (('g, 'h) injected * (('i, 'j) injected * ('k, 'l) injected) ->
+            State.t ->
+            ('g, 'h) reified * (('i, 'j) reified * ('k, 'l) reified)) *
+           ('m * ('n * ('o * 'p)) -> ('m * ('n * 'o)) * 'p) *
+           (('q -> 'r -> 's -> 't) -> 'q * ('r * 's) -> 't)
 
 val four : unit ->
-  ((('a, 'g) injected -> ('b, 'h) injected -> ('c, 'i) injected -> ('d, 'j)  injected -> State.t Stream.internal goal') ->
-    (('a, 'g) injected * (('b, 'h) injected * (('c, 'i) injected * (('d, 'j) injected * State.t Stream.internal)))) goal') *
-  (('l -> 'm -> 'n -> 'o -> 'q) ->
-    'l * ('m * ('n * 'o)) -> 'q) *
-  (State.t Stream.t ->
-     ('r, 's) injected * (('t, 'u) injected * (('v, 'w) injected * ('x, 'y) injected)) ->
-     ('r, 's) reified Stream.t *
-     (('t, 'u) reified Stream.t *
-      (('v, 'w) reified Stream.t *
-       (('x, 'y) reified Stream.t)))) *
-  ('b1 * ('c1 * ('d1 * ('e1 * 'f1))) -> ('b1 * ('c1 * ('d1 * 'e1)))  * 'f1)
+           ((('a, 'b) injected ->
+             ('c, 'd) injected ->
+             ('e, 'f) injected -> ('g, 'h) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected *
+            (('c, 'd) injected *
+             (('e, 'f) injected *
+              (('g, 'h) injected * State.t Stream.t)))) *
+           (('i, 'j) injected *
+            (('k, 'l) injected * (('m, 'n) injected * ('o, 'p) injected)) ->
+            State.t ->
+            ('i, 'j) reified *
+            (('k, 'l) reified * (('m, 'n) reified * ('o, 'p) reified))) *
+           ('q * ('r * ('s * ('t * 'u))) -> ('q * ('r * ('s * 't))) * 'u) *
+           (('v -> 'w -> 'x -> 'y -> 'z) -> 'v * ('w * ('x * 'y)) -> 'z)
 
 val five : unit ->
-  ((('a, 'g) injected -> ('b, 'h) injected -> ('c, 'i) injected -> ('d, 'j)  injected -> ('e, 'k) injected -> State.t Stream.internal goal') ->
-   (('a, 'g) injected *
-    (('b, 'h) injected *
-     (('c, 'i) injected * (('d, 'j) injected * (('e, 'k) injected * State.t Stream.internal))))) goal') *
-  (('l -> 'm -> 'n -> 'o -> 'p -> 'q) ->
-    'l * ('m * ('n * ('o * 'p))) -> 'q) *
-  (State.t Stream.t ->
-     ('r, 's) injected *
-     (('t, 'u) injected *
-      (('v, 'w) injected * (('x, 'y) injected * ('z, 'a1) injected))) ->
-     ('r, 's) reified Stream.t *
-     (('t, 'u) reified Stream.t *
-      (('v, 'w) reified Stream.t *
-       (('x, 'y) reified Stream.t *
-        ('z, 'a1) reified Stream.t)))) *
-  ('b1 * ('c1 * ('d1 * ('e1 * ('f1 * 'g1)))) -> ('b1 * ('c1 * ('d1 * ('e1 * 'f1)))) * 'g1)
+           ((('a, 'b) injected ->
+             ('c, 'd) injected ->
+             ('e, 'f) injected ->
+             ('g, 'h) injected -> ('i, 'j) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected *
+            (('c, 'd) injected *
+             (('e, 'f) injected *
+              (('g, 'h) injected *
+               (('i, 'j) injected * State.t Stream.t))))) *
+           (('k, 'l) injected *
+            (('m, 'n) injected *
+             (('o, 'p) injected * (('q, 'r) injected * ('s, 't) injected))) ->
+            State.t ->
+            ('k, 'l) reified *
+            (('m, 'n) reified *
+             (('o, 'p) reified * (('q, 'r) reified * ('s, 't) reified)))) *
+           ('u * ('v * ('w * ('x * ('y * 'z)))) ->
+            ('u * ('v * ('w * ('x * 'y)))) * 'z) *
+           (('a1 -> 'b1 -> 'c1 -> 'd1 -> 'e1 -> 'f1) ->
+            'a1 * ('b1 * ('c1 * ('d1 * 'e1))) -> 'f1)
 
 (** {3 The same numerals with conventional names} *)
 val q : unit ->
-  ((('a,'c) injected -> State.t Stream.internal goal') -> (('a, 'c) injected * State.t Stream.internal) goal') *
-  (('d -> 'e) -> 'd -> 'e) *
-  (State.t Stream.t ->
-    ('f, 'g) injected -> ('f, 'g) reified Stream.t) *
-  ('h -> 'h)
+           ((('a, 'b) injected -> goal) ->
+            State.t -> ('a, 'b) injected * State.t Stream.t) *
+           (('c, 'd) injected -> State.t -> ('c, 'd) reified) * ('e -> 'e) *
+           (('f -> 'g) -> 'f -> 'g)
 
 val qr : unit ->
-  ((('a,'d) injected -> ('b,'e) injected -> State.t Stream.internal goal') ->
-    (('a, 'd) injected * (('b, 'e) injected * State.t Stream.internal)) goal') *
-  (('f -> 'g -> 'h) -> 'f * 'g -> 'h) *
-  (State.t Stream.t ->
-    ('i, 'j) injected * ('k, 'l) injected ->
-    ('i, 'j) reified Stream.t *
-    ('k, 'l) reified Stream.t) *
-  ('m * ('n * 'o) -> ('m * 'n) * 'o)
+           ((('a, 'b) injected -> ('c, 'd) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected * (('c, 'd) injected * State.t Stream.t)) *
+           (('e, 'f) injected * ('g, 'h) injected ->
+            State.t -> ('e, 'f) reified * ('g, 'h) reified) *
+           ('i * ('j * 'k) -> ('i * 'j) * 'k) *
+           (('l -> 'm -> 'n) -> 'l * 'm -> 'n)
 
 val qrs : unit ->
-  ((('a,'e) injected -> ('b, 'f) injected -> ('c, 'g) injected -> State.t Stream.internal goal') ->
-    (('a, 'e) injected * (('b, 'f) injected * (('c, 'g) injected * State.t Stream.internal))) goal') *
-  (('h -> 'i -> 'j -> 'k) -> 'h * ('i * 'j) -> 'k) *
-  (State.t Stream.t ->
-    ('l, 'm) injected * (('n, 'o) injected * ('p, 'q) injected) ->
-    ('l, 'm) reified Stream.t *
-    (('n, 'o) reified Stream.t *
-    ('p, 'q) reified Stream.t)) *
-  ('r * ('s * ('t * 'u)) -> ('r * ('s * 't)) * 'u)
+           ((('a, 'b) injected ->
+             ('c, 'd) injected -> ('e, 'f) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected *
+            (('c, 'd) injected *
+             (('e, 'f) injected * State.t Stream.t))) *
+           (('g, 'h) injected * (('i, 'j) injected * ('k, 'l) injected) ->
+            State.t ->
+            ('g, 'h) reified * (('i, 'j) reified * ('k, 'l) reified)) *
+           ('m * ('n * ('o * 'p)) -> ('m * ('n * 'o)) * 'p) *
+           (('q -> 'r -> 's -> 't) -> 'q * ('r * 's) -> 't)
 
 val qrst : unit ->
-  ((('a, 'g) injected -> ('b, 'h) injected -> ('c, 'i) injected -> ('d, 'j)  injected -> State.t Stream.internal goal') ->
-    (('a, 'g) injected * (('b, 'h) injected * (('c, 'i) injected * (('d, 'j) injected * State.t Stream.internal)))) goal') *
-  (('l -> 'm -> 'n -> 'o -> 'q) ->
-    'l * ('m * ('n * 'o)) -> 'q) *
-  (State.t Stream.t ->
-   ('r, 's) injected * (('t, 'u) injected * (('v, 'w) injected * ('x, 'y) injected)) ->
-   ('r, 's) reified Stream.t *
-   (('t, 'u) reified Stream.t *
-    (('v, 'w) reified Stream.t *
-     (('x, 'y) reified Stream.t)))) *
-   ('b1 * ('c1 * ('d1 * ('e1 * 'f1))) -> ('b1 * ('c1 * ('d1 * 'e1)))  * 'f1)
+           ((('a, 'b) injected ->
+             ('c, 'd) injected ->
+             ('e, 'f) injected -> ('g, 'h) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected *
+            (('c, 'd) injected *
+             (('e, 'f) injected *
+              (('g, 'h) injected * State.t Stream.t)))) *
+           (('i, 'j) injected *
+            (('k, 'l) injected * (('m, 'n) injected * ('o, 'p) injected)) ->
+            State.t ->
+            ('i, 'j) reified *
+            (('k, 'l) reified * (('m, 'n) reified * ('o, 'p) reified))) *
+           ('q * ('r * ('s * ('t * 'u))) -> ('q * ('r * ('s * 't))) * 'u) *
+           (('v -> 'w -> 'x -> 'y -> 'z) -> 'v * ('w * ('x * 'y)) -> 'z)
+
+val qrstu : unit ->
+           ((('a, 'b) injected ->
+             ('c, 'd) injected ->
+             ('e, 'f) injected ->
+             ('g, 'h) injected -> ('i, 'j) injected -> goal) ->
+            State.t ->
+            ('a, 'b) injected *
+            (('c, 'd) injected *
+             (('e, 'f) injected *
+              (('g, 'h) injected *
+               (('i, 'j) injected * State.t Stream.t))))) *
+           (('k, 'l) injected *
+            (('m, 'n) injected *
+             (('o, 'p) injected * (('q, 'r) injected * ('s, 't) injected))) ->
+            State.t ->
+            ('k, 'l) reified *
+            (('m, 'n) reified *
+             (('o, 'p) reified * (('q, 'r) reified * ('s, 't) reified)))) *
+           ('u * ('v * ('w * ('x * ('y * 'z)))) ->
+            ('u * ('v * ('w * ('x * 'y)))) * 'z) *
+           (('a1 -> 'b1 -> 'c1 -> 'd1 -> 'e1 -> 'f1) ->
+            'a1 * ('b1 * ('c1 * ('d1 * 'e1))) -> 'f1)
 
  (** Tabling primitives.
      Tabling allows to cache answers of the goal between different queries.
@@ -394,9 +465,9 @@ module Tabling :
       (('h -> 'i -> 'j -> 'k -> 'l -> 'm) -> 'h * ('i * ('j * ('k * 'l))) -> 'm) *
       ('b1 * ('c1 * ('d1 * ('e1 * ('f1 * 'g1)))) -> ('b1 * ('c1 * ('d1 * ('e1 * 'f1)))) * 'g1)
 
-    val tabled : (unit -> (('a -> State.t Stream.internal) -> 'b) * ('c -> 'd -> goal) * ('a -> 'd * State.t)) -> 'c -> 'b
+    val tabled : (unit -> (('a -> State.t Stream.t) -> 'b) * ('c -> 'd -> goal) * ('a -> 'd * State.t)) -> 'c -> 'b
 
-    val tabledrec : (unit -> (('a -> State.t Stream.internal) -> 'b -> 'c) * ('d -> 'e -> goal) * ('a -> 'e * State.t)) -> (('b -> 'c) -> 'd) -> 'b -> 'c
+    val tabledrec : (unit -> (('a -> State.t Stream.t) -> 'b -> 'c) * ('d -> 'e -> goal) * ('a -> 'e * State.t)) -> (('b -> 'c) -> 'd) -> 'b -> 'c
   end
 
 (** {2 Building reifiers for a custom type compositionally} *)

--- a/src/MiniKanrenCore.mli
+++ b/src/MiniKanrenCore.mli
@@ -242,31 +242,6 @@ object
   method reify: (helper -> ('a, 'b) injected -> 'b) -> 'b
 end
 
-(* module RunCurried : sig
-  (** {3 Predefined numerals (one to five)} *)
-  val one : unit ->
-           ((('a, 'b) injected -> goal) ->
-            State.t -> ('a, 'b) injected * State.t Stream.t) *
-           (('c, 'd) injected -> State.t -> ('c, 'd) reified) * ('e -> 'e)
-
-  (** Successor function *)
-  val succ : (unit ->
-            ('a -> State.t -> 'b) * ('c -> State.t -> 'd) * ('e -> 'f * 'g)) ->
-           unit ->
-           ((('h, 'i) injected -> 'a) -> State.t -> ('h, 'i) injected * 'b) *
-           (('j, 'k) injected * 'c -> State.t -> ('j, 'k) reified * 'd) *
-           ('l * 'e -> ('l * 'f) * 'g)
-
-
-  val run :
-           (unit ->
-            ('a -> State.t -> 'b) * ('c -> State.t -> 'd) *
-            ('b -> 'c * State.t Stream.t)) ->
-           'a -> ('d Stream.t -> 'e) -> 'e
-
-end *)
-
-
 (** Successor function *)
 val succ : (unit ->
             ('a -> State.t -> 'b) * ('c -> State.t -> 'd) * ('e -> 'f * 'g) *


### PR DESCRIPTION
1) New run interface:

```
run qr (fun q r -> q === r) (fun q r -> q#prj, r#prj)
```

2) Get rid of intermediate Streams representation (with `Lazy.t`)

In a collaboration with @Kakadu 